### PR TITLE
Recommended profile

### DIFF
--- a/src/app/auth/thunks.ts
+++ b/src/app/auth/thunks.ts
@@ -48,9 +48,14 @@ export const onLogin = createAsyncThunk(
 export const onLogout = createAsyncThunk(
     'auth/onLogout',
     async (data = undefined, { dispatch }) => {
+        // Clear auth data
         sessionStorage.removeItem('access');
         sessionStorage.removeItem('refresh');
         sessionStorage.removeItem('user');
+
+        // Clear current recommended user/profile
+        localStorage.removeItem('recommendedUser');
+        localStorage.removeItem('recommendedCompany');
 
         // Clear data from all slices (dispatch clearSliceAction)
         dispatch(clearChatSlice());

--- a/src/app/experience/thunks.ts
+++ b/src/app/experience/thunks.ts
@@ -3,7 +3,7 @@ import { RootState } from "../store";
 import { errorNotification, successNotification } from "../../components/common/Alerts";
 import { axios_base } from "../../api/axios_base";
 import { AxiosError } from "axios";
-import { ExperienceAdded, IUserExperience, IUserExperienceById} from "../types/interfaces";
+import { ExperienceAdded, IOnGetUserExperiences, IUserExperience, IUserExperienceById} from "../types/interfaces";
 import { setErrors } from "./experienceSlice";
 
 export const onAddUserExperience = createAsyncThunk(
@@ -30,11 +30,14 @@ export const onAddUserExperience = createAsyncThunk(
 
 export const onGetUserExperiences = createAsyncThunk(
     'experience/onGetUserExperiences',
-    async (data = undefined,  { dispatch, getState }) => {
+    async (data: IOnGetUserExperiences,  { dispatch, getState }) => {
         try {
-            
             const { auth } = getState() as RootState;
+            const { user_id } = data;
             const resp = await axios_base.get<IUserExperienceById>(`experience/`, {
+                params: {
+                    user_id
+                },
                 headers: {
                     Authorization: `JWT ${ auth.access }`
                 }

--- a/src/app/extra/modalSlice.ts
+++ b/src/app/extra/modalSlice.ts
@@ -4,12 +4,14 @@ export interface ModalState {
     openProfileModal: boolean;
     openRolesModal: boolean;
     openExperienceModal: boolean;
+    openSkillModal: boolean;
 }
 
 export const initialState: ModalState = {
     openProfileModal: false,
     openRolesModal: false,
     openExperienceModal: false,
+    openSkillModal: false
 }
 
 export const modalSlice = createSlice({

--- a/src/app/match/matchSlice.ts
+++ b/src/app/match/matchSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 
-import { ICompanyProfile, IUserProfile } from '../types/interfaces';
+import { ICompanyProfile, ICurrentUser, IUserProfile } from '../types/interfaces';
 import { onGetCompanyMatch, onGetUserMatch, onRetrieveCompanyMatchesList, onRetrieveUserMatchesList } from './thunks';
 
 
@@ -9,17 +9,27 @@ import { onGetCompanyMatch, onGetUserMatch, onRetrieveCompanyMatchesList, onRetr
 export interface MatchesState {
     errors: any;
     loading: boolean;
-    user: IUserProfile | null;
-    company: ICompanyProfile | null;
+
+    usersQueue: ICurrentUser[]; // queue
+    currentUser: ICurrentUser | null; //
+
+    companiesQueue: ICurrentUser[];
+    currentCompany: ICurrentUser | null;
+
     userMatches: ICompanyProfile[];
     companyMatches: IUserProfile[];
 }
 
 export const initialState: MatchesState = {
     errors: {},
-    company: null,
-    user: null, 
     loading: false,
+    
+    usersQueue: [],
+    currentUser: null, 
+
+    companiesQueue: [],
+    currentCompany: null,
+
     userMatches: [],
     companyMatches: [],
 }
@@ -36,6 +46,22 @@ export const matchesSlice = createSlice({
         },
         clearMatchSlice: () => {
           return initialState;
+        },
+        dequeueCompany: (state) => {
+            const [currentCompany, ...companies] = state.companiesQueue;
+            return {
+              ...state,
+              companiesQueue: companies,
+              currentCompany
+            }
+        },
+        dequeueUser: (state) => {
+            const [currentUser, ...users] = state.usersQueue;
+            return {
+              ...state,
+              usersQueue: users,
+              currentUser
+            }
         }
     },
     extraReducers(builder) {
@@ -60,7 +86,7 @@ export const matchesSlice = createSlice({
             ...state,
             errors: {},
             loading: false,
-            user: payload
+            usersQueue: payload
           }
         })
 
@@ -80,12 +106,12 @@ export const matchesSlice = createSlice({
           }
         })
     
-        builder.addCase(onGetUserMatch.fulfilled, (state, { payload }) => {
+        builder.addCase(onGetUserMatch.fulfilled, (state, { payload }) => { 
           return {
             ...state,
             errors: {},
             loading: false,
-            company: payload
+            companiesQueue: payload
           }
         })
 
@@ -142,6 +168,6 @@ export const matchesSlice = createSlice({
     }
 })
 
-export const { setErrors, clearMatchSlice } = matchesSlice.actions;
+export const { setErrors, clearMatchSlice, dequeueCompany, dequeueUser} = matchesSlice.actions;
 
 export default matchesSlice.reducer;

--- a/src/app/match/thunks.ts
+++ b/src/app/match/thunks.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { RootState } from "../store";
-import { ICompanyProfile, IUserProfile, IOnMatchCompany, IOnMatchUser, IsMatch } from '../types/interfaces';
+import { ICompanyProfile, IUserProfile, IOnMatchCompany, IOnMatchUser, IsMatch, ICurrentUser } from '../types/interfaces';
 import { axios_base } from "../../api/axios_base";
 import { setErrors } from "./matchSlice";
 import { AxiosError } from "axios";
@@ -10,12 +10,28 @@ export const onGetCompanyMatch = createAsyncThunk(
     async (data = undefined,  { dispatch, getState }) => {
         try {
             const { auth } = getState() as RootState;
-            const resp = await axios_base.get<IUserProfile>(`match/get_company_match/`, {
+            const resp = await axios_base.get<ICurrentUser[]>(`match/get_company_match/`, {
                 headers: {
                     Authorization: `JWT ${ auth.access }`
                 }
             });
-            return resp.data;   
+
+            const baseUsers: ICurrentUser[]  = resp.data.map(base_user => ({
+                ...base_user,
+                user: {
+                    id: base_user.user!.id,
+                    about: base_user.user!.about,
+                    expected_salary: base_user.user!.expected_salary,
+                    name: base_user.user!.name,
+                    lastname: base_user.user!.lastname,
+                    base_user: base_user.user!.base_user,
+                    location: base_user.user!.location,
+                    modality: base_user.user!.modality,
+                    position: base_user.user!.position,
+                    image: base_user?.user?.image ? `${ import.meta.env.DEV ? import.meta.env.VITE_API_URL_DEV : import.meta.env.VITE_API_URL_PROD }`.slice(0, -1) + base_user?.user?.image : null
+                },
+            }));
+            return baseUsers;   
         } catch (error) {
             const err = error as AxiosError;
             dispatch(setErrors(err.response?.data));
@@ -29,12 +45,27 @@ export const onGetUserMatch = createAsyncThunk(
     async (data = undefined,  { dispatch, getState }) => {
         try {
             const { auth } = getState() as RootState;
-            const resp = await axios_base.get<ICompanyProfile>(`match/get_user_match/`, {
+            const resp = await axios_base.get<ICurrentUser[]>(`match/get_user_match/`, {
                 headers: {
                     Authorization: `JWT ${ auth.access }`
                 }
             });
-            return resp.data;   
+            const baseUsers: ICurrentUser[]  = resp.data.map(base_user => ({
+                ...base_user,
+                company: {
+                    id:        base_user.company!.id,
+                    name:      base_user.company!.name,
+                    about:     base_user.company!.about,
+                    mission:   base_user.company!.mission,
+                    vision:    base_user.company!.vision,
+                    verified:  base_user.company!.verified,
+                    location:  base_user.company!.location,
+                    sector:    base_user.company!.sector,
+                    base_user: base_user.company!.base_user,
+                    image: base_user?.company?.image ? `${ import.meta.env.DEV ? import.meta.env.VITE_API_URL_DEV : import.meta.env.VITE_API_URL_PROD }`.slice(0, -1) + base_user.company.image : null
+                }
+            }));
+            return baseUsers;   
         } catch (error) {
             const err = error as AxiosError;
             dispatch(setErrors(err.response?.data));

--- a/src/app/roles/thunks.ts
+++ b/src/app/roles/thunks.ts
@@ -3,7 +3,7 @@ import { axios_base } from '../../api/axios_base';
 import { AxiosError } from 'axios';
 import { setErrors } from './rolesSlice';
 import { errorNotification, successNotification } from '../../components/common/Alerts';
-import { ICompanyRoles, ICompanyRolesById, INewRole, IOnSaveNewRole } from '../types/interfaces';
+import { ICompanyRoles, ICompanyRolesById, INewRole, IOnGetCompanyRolesQueryParams, IOnSaveNewRole } from '../types/interfaces';
 import { RootState } from '../store';
 
 export const onAddCompanyRoles = createAsyncThunk(
@@ -29,10 +29,13 @@ export const onAddCompanyRoles = createAsyncThunk(
 
 export const onGetCompanyRoles = createAsyncThunk(
     'roles/onGetCompanyRoles',
-    async (data = undefined,  { dispatch, getState }) => {
+    async (data: IOnGetCompanyRolesQueryParams,  { dispatch, getState }) => {
         try {
+            // Added query params to get roles in match click view
             const { auth } = getState() as RootState;
+            const { company_id } = data;
             const resp = await axios_base.get<ICompanyRolesById[]>(`company-roles/`, {
+                params: { company_id },
                 headers: {
                     Authorization: `JWT ${ auth.access }`
                 }

--- a/src/app/skill/thunks.ts
+++ b/src/app/skill/thunks.ts
@@ -3,7 +3,7 @@ import { RootState } from "../store";
 import { errorNotification, successNotification } from "../../components/common/Alerts";
 import { axios_base } from "../../api/axios_base";
 import { AxiosError } from "axios";
-import {  SkillAdded, IUserSkillById, ISkill } from "../types/interfaces";
+import {  SkillAdded, IUserSkillById, ISkill, IOnGetUserSkills } from "../types/interfaces";
 import { setErrors } from "./skillSlice";
 
 export const onAddUserSkill = createAsyncThunk(
@@ -30,10 +30,14 @@ export const onAddUserSkill = createAsyncThunk(
 
 export const onGetUserSkills = createAsyncThunk(
     'skills/onGetUserSkills',
-    async (data = undefined,  { dispatch, getState }) => {
+    async (data: IOnGetUserSkills,  { dispatch, getState }) => {
         try {
             const { auth } = getState() as RootState;
+            const { user_id } = data;
             const resp = await axios_base.get<IUserSkillById>(`skills/`, {
+                params: {
+                    user_id
+                },
                 headers: {
                     Authorization: `JWT ${ auth.access }`
                 }

--- a/src/app/types/interfaces.ts
+++ b/src/app/types/interfaces.ts
@@ -58,6 +58,10 @@ export interface ICompanyRoles {
     roles: Role[];
 }
 
+export interface IOnGetCompanyRolesQueryParams {
+    company_id: number;
+}
+
 export interface ICompanyRolesById {
     id:          number;
     link:        string;
@@ -146,6 +150,10 @@ export interface IUserExperience {
     user: number;
 }
 
+export interface IOnGetUserExperiences {
+    user_id: number;
+}
+
 export interface ExperienceAdded {
     id:          number;
     role:        number;
@@ -171,6 +179,10 @@ export interface ISkill {
     name: string;
     description: string;
     user: number;
+}
+
+export interface IOnGetUserSkills {
+    user_id: number;
 }
 
 export interface SkillAdded {

--- a/src/components/chat/UserChatList.tsx
+++ b/src/components/chat/UserChatList.tsx
@@ -2,7 +2,7 @@ import { useAppSelector } from "../../app/hooks"
 import { UserChat } from "./UserChat";
 
 export const UserChatList = () => {
-    const { chatUsers } = useAppSelector(state => state.chat);
+    const { chatUsers } = useAppSelector(state => state.chat); // socket users
     const { userMatches, companyMatches } = useAppSelector(state => state.match);
     const { user_data } = useAppSelector(state => state.auth);
 

--- a/src/pages/auth/RolesModalEdit.tsx
+++ b/src/pages/auth/RolesModalEdit.tsx
@@ -31,7 +31,9 @@ export const RolesModalEdit = () => {
             })).unwrap();
             dispatch(setModalClosedRoles());
             dispatch(clearRoles());
-            dispatch(onGetCompanyRoles());
+            dispatch(onGetCompanyRoles({
+                company_id: user_data!.company!.id
+            }));
         } catch (error) {
             
         }

--- a/src/pages/experience/ExperienceModalAdd.tsx
+++ b/src/pages/experience/ExperienceModalAdd.tsx
@@ -29,7 +29,9 @@ export const ExperienceModalAdd = () => {
                 user: user_data!.user!.id
             })).unwrap();
             dispatch(setModalClosedExperience());
-            dispatch(onGetUserExperiences());
+            dispatch(onGetUserExperiences({
+                user_id: user_data!.user!.id
+            }));
         } catch (error) {
             
         }

--- a/src/pages/home/Profile.tsx
+++ b/src/pages/home/Profile.tsx
@@ -3,7 +3,6 @@ import { CompanyProfile } from "./profile/company/CompanyProfile"
 import { UserProfile } from "./profile/user/UserProfile"
 
 export const Profile = () => {
-
     const { user_data } = useAppSelector(state => state.auth);
 
     return (

--- a/src/pages/home/profile/HeaderProfile.tsx
+++ b/src/pages/home/profile/HeaderProfile.tsx
@@ -3,6 +3,11 @@ import { SettingsProfile } from "./SettingsProfile"
 import { defaultImageProfile } from '../../../components/common/constants';
 import { useAppDispatch, useAppSelector } from '../../../app/hooks';
 import { onGetCurrentUserData, onUpdateProfilePicture } from '../../../app/auth/thunks';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { setActiveUserChat } from '../../../app/chat/chatSlice';
+import { onMatchCompany, onMatchUser } from '../../../app/match/thunks';
+import { neutralNotification } from '../../../components/common/Alerts';
+import { useState } from 'react';
 
 interface Props {
     name: string;
@@ -14,11 +19,18 @@ interface Props {
 export const HeaderProfile: FC<Props> = ({ name, position, location, image }) => {
 
     const fileInputPicture = useRef<HTMLInputElement>(null);
-
     const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+
     const { user_data, access } = useAppSelector(state => state.auth);
     const { positions, sectors } = useAppSelector(state => state.form);
+    const { userMatches, companyMatches } = useAppSelector(state => state.match);
+    const { pathname } = useLocation();
 
+    const storageRecommendedCompany = JSON.parse(localStorage.getItem('recommendedCompany') || 'null') || null;
+    const storageRecommendedUser = JSON.parse(localStorage.getItem('recommendedUser') || 'null') || null;
+
+    const [enabledConnect, setEnabledConnect] = useState<boolean>(true);
 
     const onChangeProfilePicture = async (e: React.ChangeEvent<HTMLInputElement>) => {
         e.preventDefault();
@@ -37,7 +49,39 @@ export const HeaderProfile: FC<Props> = ({ name, position, location, image }) =>
             }
         }
     }
-  
+
+    const onMatchConnect = () => {
+        // auth user/company is being sent in onMatchCompany/onMatchUser Authorization header
+        if (user_data?.user){
+            console.log(storageRecommendedCompany?.company?.id)
+            dispatch(onMatchUser({
+                like: true,
+                company_id: storageRecommendedCompany?.company?.id
+            }));
+        }
+        else {
+            dispatch(onMatchCompany({
+                like: true,
+                user_id: storageRecommendedUser?.user?.id
+            }));
+        }
+        neutralNotification('Match enviado con éxito 😎');
+        setEnabledConnect(false);
+    }
+
+    const onSendNewMessage = () => {
+        dispatch(setActiveUserChat(
+            storageRecommendedCompany?.company?.id || storageRecommendedUser?.user?.id
+        ));
+        navigate('/messages');
+    }
+
+    const showConnectButton: boolean = storageRecommendedCompany && user_data?.user && !userMatches.map(company => company.base_user).includes(storageRecommendedCompany.id) // recommended company ISN'Tin the auth user's matches
+                                        || storageRecommendedUser && user_data?.company && !companyMatches.map(user => user.base_user).includes(storageRecommendedUser.id) // recommended user ISN'T in the auth company's matches
+    
+    const showMessageButton: boolean = storageRecommendedCompany && user_data?.user && userMatches.map(company => company.base_user).includes(storageRecommendedCompany.id) // recommended company IS in the auth user's matches
+                                        || storageRecommendedUser && user_data?.company && companyMatches.map(user => user.base_user).includes(storageRecommendedUser.id) // recommended user IS in the auth company's matches
+ 
     return (
       <div className="bg-white rounded-lg shadow-xl pb-8">
           <SettingsProfile />
@@ -48,13 +92,17 @@ export const HeaderProfile: FC<Props> = ({ name, position, location, image }) =>
               
           </div>
           <div className="flex flex-col items-center -mt-20">
-                <img src={ image || defaultImageProfile } className="w-40 h-40 border-4 border-white rounded-full" />
-                <button className="flex items-center px-6 py-1.5 space-x-2 hover:bg-pink-50" onClick={ () => fileInputPicture.current && fileInputPicture.current.click() }>
-                    <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-                    <span className="text-sm text-gray-500">Editar foto</span>
-                </button>
+                <img src={ image || defaultImageProfile } className="w-40 h-40 border-4 border-white rounded-full" />                    
+                {
+                    !pathname.includes('recommended-profile') && (
+                        <button className="flex items-center px-6 py-1.5 space-x-2 hover:bg-pink-50" onClick={ () => fileInputPicture.current && fileInputPicture.current.click() }>
+                            <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                            <span className="text-sm text-gray-500">Editar foto</span>
+                        </button>
+                    )
+                }       
                 <input type="file" className="hidden" ref={ fileInputPicture } onChange={ onChangeProfilePicture } />
-              <div className="flex items-center space-x-2 mt-2">
+              <div className="flex items-center space-x-2">
                   <p className="text-2xl capitalize">{ name }</p>
                   <span className="bg-indigo-500 rounded-full p-1" title="Verified">
                       <svg xmlns="http://www.w3.org/2000/svg" className="text-gray-100 h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -64,28 +112,53 @@ export const HeaderProfile: FC<Props> = ({ name, position, location, image }) =>
               </div>
               <p className="text-gray-700 capitalize">
                 {
-                    user_data?.user 
-                    ? positions.find(p => p.id === position )?.display
-                    : user_data?.company && sectors.find(s => s.id === position)?.display
+                    // My profile view
+                    !pathname.includes('recommended-profile') ? (
+                        user_data?.user 
+                        ? positions.find(p => p.id === position )?.display
+                        : user_data?.company && sectors.find(s => s.id === position)?.display
+                    ) : (
+                        // recommended profile view
+                        storageRecommendedUser
+                        ? positions.find(p => p.id === storageRecommendedUser.user.position)?.display
+                        : storageRecommendedCompany && sectors.find(s => s.id === storageRecommendedCompany.company.sector)?.display
+                    )
                 } 
               </p>
               <p className="text-sm text-gray-500 capitalize">{ location }</p>
           </div>
           <div className="flex-1 flex flex-col items-center lg:items-end justify-end px-8 mt-2">
-              <div className="flex items-center space-x-4 mt-2">
-                  <button className="flex items-center bg-gradient-to-r from-indigo-500 to-red-500  hover:bg-gradient-to-l hover:from-red-600 hover:to-indigo-600 text-white px-4 py-2 rounded text-sm space-x-2 transition duration-100">
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                          <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"></path>
-                      </svg>
-                      <span>Connect</span>
-                  </button>
-                  <button className="flex items-center bg-gradient-to-r from-indigo-500 to-red-500  hover:bg-gradient-to-l hover:from-red-600 hover:to-indigo-600 text-white px-4 py-2 rounded text-sm space-x-2 transition duration-100">
-                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                          <path fillRule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clipRule="evenodd"></path>
-                      </svg>
-                      <span>Mensaje</span>
-                  </button>
-              </div>
+                {
+                    pathname.includes('recommended-profile') && (
+                        <div className="flex items-center space-x-4 mt-2">           
+                            {
+                                // check if base_user (id) of the recommended user/company is NOT in the user/company matches in order to show the button
+                                showConnectButton && ( 
+                                    <button className="flex items-center bg-gradient-to-r from-indigo-500 to-red-500  hover:bg-gradient-to-l hover:from-red-600 hover:to-indigo-600 text-white px-4 py-2 rounded text-sm space-x-2 transition duration-100"
+                                        onClick={ onMatchConnect } disabled={ !enabledConnect }
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                            <path d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 016 6H2a6 6 0 016-6zM16 7a1 1 0 10-2 0v1h-1a1 1 0 100 2h1v1a1 1 0 102 0v-1h1a1 1 0 100-2h-1V7z"></path>
+                                        </svg>
+                                        <span>Conectar</span>
+                                    </button>
+                                )
+                            }
+                            {
+                                showMessageButton && (
+                                    <button className="flex items-center bg-gradient-to-r from-indigo-500 to-red-500  hover:bg-gradient-to-l hover:from-red-600 hover:to-indigo-600 text-white px-4 py-2 rounded text-sm space-x-2 transition duration-100"
+                                        onClick={ onSendNewMessage } 
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                            <path fillRule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clipRule="evenodd"></path>
+                                        </svg>
+                                        <span>Mensaje</span>
+                                    </button>
+                                )
+                            }               
+                        </div>
+                    )
+                }            
           </div>
       </div>
     )

--- a/src/pages/home/profile/SettingsProfile.tsx
+++ b/src/pages/home/profile/SettingsProfile.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch, useAppSelector } from "../../../app/hooks";
 import { setModalOpenProfile } from "../../../app/extra/modalSlice";
 import { EditCompanyModal } from "../../auth/EditCompanyModal";
 import { EditUserModal } from "../../auth/EditUserModal";
+import { useLocation } from "react-router-dom";
 
 export const SettingsProfile = () => {
     const [isSettingsOpen, setIsSettingsOpen] = useState<boolean>(false);
@@ -11,57 +12,32 @@ export const SettingsProfile = () => {
     const { user_data } = useAppSelector(state => state.auth);
 
     const dispatch = useAppDispatch();
+    const { pathname } = useLocation();
 
     return (
-        <div className="absolute right-12 mt-4 rounded">
-            <div>
-                { open && user_data?.company && <EditCompanyModal /> }
-                { open && user_data?.user && <EditUserModal /> }
-            </div>
-            <button onClick={ () => setIsSettingsOpen(!isSettingsOpen)} className="border border-gray-400 p-2 rounded text-gray-300 hover:text-gray-300 bg-gray-100 bg-opacity-10 hover:bg-opacity-20" title="Settings">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"></path>
-                </svg>
-            </button>
-            { isSettingsOpen &&
-            <div className="bg-white absolute right-0 w-40 py-2 mt-1 border border-gray-200 shadow-2xl">
-                <div className="py-2 border-b">
-                    <p className="text-gray-400 text-xs px-6 uppercase mb-1">Settings</p>
-
-                    <button className="w-full flex items-center px-6 py-1.5 space-x-2 hover:bg-gray-200" onClick={ () => dispatch(setModalOpenProfile()) }>
-                        <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-                        <span className="text-sm text-gray-700">Edit Profile</span>
-                    </button>
-
-                    <button className="w-full flex items-center px-6 py-1.5 space-x-2 hover:bg-gray-200">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"></path>
-                        </svg>
-                        <span className="text-sm text-gray-700">Share Profile</span>
-                    </button>
-                    <button className="w-full flex items-center py-1.5 px-6 space-x-2 hover:bg-gray-200">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"></path>
-                        </svg>
-                        <span className="text-sm text-gray-700">Block User</span>
-                    </button>
-                    <button className="w-full flex items-center py-1.5 px-6 space-x-2 hover:bg-gray-200">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                        </svg>
-                        <span className="text-sm text-gray-700">More Info</span>
-                    </button>
+        !pathname.includes('recommended-profile') ? (       
+            <div className="absolute right-12 mt-4 rounded">
+                <div>
+                    { open && user_data?.company && <EditCompanyModal /> }
+                    { open && user_data?.user && <EditUserModal /> }
                 </div>
-                <div className="py-2">
-                    <p className="text-gray-400 text-xs px-6 uppercase mb-1">Feedback</p>
-                    <button className="w-full flex items-center py-1.5 px-6 space-x-2 hover:bg-gray-200">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                        </svg>
-                        <span className="text-sm text-gray-700">Report</span>
-                    </button>
-                </div>
-            </div>}
-        </div> 
+                <button onClick={ () => setIsSettingsOpen(!isSettingsOpen)} className="border border-gray-400 p-2 rounded text-gray-300 hover:text-gray-300 bg-gray-100 bg-opacity-10 hover:bg-opacity-20" title="Settings">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"></path>
+                    </svg>
+                </button>
+                { isSettingsOpen &&
+                <div className="bg-white absolute right-0 w-40 py-2 mt-1 border border-gray-200 shadow-2xl">
+                    <div className="py-2 border-b">
+                        <p className="text-gray-400 text-xs px-6 uppercase mb-1">Ajustes</p>
+
+                        <button className="w-full flex items-center px-6 py-1.5 space-x-2 hover:bg-gray-200" onClick={ () => dispatch(setModalOpenProfile()) }>
+                            <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                            <span className="text-sm text-gray-700">Editar Perfil</span>
+                        </button>
+                    </div>
+                </div> }
+            </div> 
+        ) : <></>
   )
 }

--- a/src/pages/home/profile/company/CompanyProfile.tsx
+++ b/src/pages/home/profile/company/CompanyProfile.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
 import { HeaderProfile } from "../HeaderProfile";
-import { ConnectionsProfile } from "../ConnectionsProfile";
 import { RolesProfile } from "./RolesProfile";
 import { ICurrentUser } from "../../../../app/types/interfaces";
 

--- a/src/pages/home/profile/company/RolesProfile.tsx
+++ b/src/pages/home/profile/company/RolesProfile.tsx
@@ -4,18 +4,23 @@ import { useAppDispatch, useAppSelector } from "../../../../app/hooks";
 import { RolesModal } from "../../../auth/RolesModal";
 import { onGetCompanyRoles } from "../../../../app/roles/thunks";
 import dayjs from 'dayjs'
-// import { useTimeAgo } from '../../hooks/useTimeAgo';
 
 export const RolesProfile = () => {
     
     const { openRolesModal } = useAppSelector(state => state.modal);
     const { company_roles } = useAppSelector(state => state.roles);
-    const { access } = useAppSelector(state => state.auth);
+    const { access, user_data } = useAppSelector(state => state.auth);
+    const storageRecommendedCompany = JSON.parse(localStorage.getItem('recommendedCompany') || 'null') || null
     const dispatch = useAppDispatch();
 
     useEffect(() => {
         if (access){
-            dispatch(onGetCompanyRoles());
+            // Check if i'm the company or the user is viewing my profile
+            const company_id = user_data?.company?.id || storageRecommendedCompany?.company?.id
+
+            dispatch(onGetCompanyRoles({
+                company_id: company_id!
+            }));
         }
         
     }, [access]);
@@ -26,10 +31,14 @@ export const RolesProfile = () => {
                 { openRolesModal && <RolesModal /> }
             </div>
             <h4 className="text-xl text-gray-900 font-bold">Roles que buscamos</h4>
-            <button className="flex items-center px-6 py-1.5 space-x-2 hover:bg-pink-50" onClick={ () => dispatch( setModalOpenRoles()) }>
-                <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-                <span className="text-sm text-gray-500">Modificar roles</span>
-            </button>
+            {
+                user_data?.company?.id && (
+                    <button className="flex items-center px-6 py-1.5 space-x-2 hover:bg-pink-50" onClick={ () => dispatch( setModalOpenRoles()) }>
+                        <svg className="feather feather-edit h-4 w-4 text-gray-400" fill="none" height="24" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                        <span className="text-sm text-gray-500">Modificar roles</span>
+                    </button>
+                )
+            } 
             <div className="relative px-4 divide-y-2 divide-gray-100">
                 {
                     company_roles.map(role => (

--- a/src/pages/matches/Card.tsx
+++ b/src/pages/matches/Card.tsx
@@ -8,38 +8,64 @@ import {
   } from 'react-swipeable-list';
   import 'react-swipeable-list/dist/styles.css';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { onGetCompanyMatch, onGetUserMatch, onMatchCompany, onMatchUser, onRetrieveCompanyMatchesList, onRetrieveUserMatchesList } from '../../app/match/thunks';
 import { defaultImageProfile } from '../../components/common/constants';
-import { LoadingScreen } from '../../components/common/LoadingScreen';
 import { setActiveUserChat } from '../../app/chat/chatSlice';
 import { neutralNotification } from '../../components/common/Alerts';
+import { dequeueCompany, dequeueUser } from '../../app/match/matchSlice';
+import { ICompanyProfile, IUserProfile } from '../../app/types/interfaces';
 
 export const Card = () => {
     
     const { user_data } =  useAppSelector(state => state.auth);
-    const { user, company, loading } =  useAppSelector(state => state.match);
+    const { currentUser, currentCompany, companiesQueue, usersQueue } =  useAppSelector(state => state.match);
     const { userMatches, companyMatches } =  useAppSelector(state => state.match);
     const { positions, sectors } =  useAppSelector(state => state.form);
+
+    const [user, setUser] = useState<IUserProfile | null>(null);
+    const [company, setCompany] = useState<ICompanyProfile | null>(null);
+
 
     const dispatch =  useAppDispatch();
     const navigate = useNavigate();
 
 
     useEffect(() => {
-        if (user_data?.company || user_data?.user){
+        if (user_data?.user && !currentCompany){
             onNextMatch();
-        }
-        
+        }       
+        else if (user_data?.company && !currentUser){
+            onNextMatch();
+        }       
     }, [user_data]);
 
-    const onNextMatch = () => {
-        if (user_data?.user){
-            dispatch(onGetUserMatch())
+    useEffect(() => {
+        if (currentUser){
+            setUser(currentUser.user);
         }
-        else {
-            dispatch(onGetCompanyMatch());
+    }, [currentUser]);
+
+    useEffect(() => {
+        if (currentCompany){
+            setCompany(currentCompany.company);
+        }
+    }, [currentCompany]);
+
+
+    const onNextMatch = async () => {
+        if (user_data?.user){   
+            if (companiesQueue.length === 0){
+                await dispatch(onGetUserMatch()).unwrap();
+            }
+            dispatch(dequeueCompany());
+        }
+        else if (user_data?.company){
+            if (usersQueue.length === 0){
+                await dispatch(onGetCompanyMatch()).unwrap();
+            }
+            dispatch(dequeueUser());
         }
     }
 
@@ -135,7 +161,7 @@ export const Card = () => {
     const leadingActions = () => (
         <LeadingActions>
         <SwipeAction onClick={() => swipeMatchLike() }>
-            Like
+            ''
         </SwipeAction>
         </LeadingActions>
     );
@@ -145,18 +171,20 @@ export const Card = () => {
         <SwipeAction
             onClick={() => swipeMatchDislike() }
         >
-            Dislike
+           ''
         </SwipeAction>
         </TrailingActions>
     );
 
-    if (loading){
-        return <LoadingScreen />
+    const onNavigateRecommendedProfile = () => {
+        if (user_data?.user){
+            localStorage.setItem('recommendedCompany', JSON.stringify(currentCompany));
+        }
+        else {
+            localStorage.setItem('recommendedUser', JSON.stringify(currentUser));
+        }
+        navigate('/recommended-profile');
     }
-
-    const apiPath = `${ import.meta.env.DEV ? import.meta.env.VITE_API_URL_DEV : import.meta.env.VITE_API_URL_PROD }`.slice(0, -1);
-
-    // alert(image)
 
     return (
         <div className="h-screen bg-gray-200 flex justify-center items-center p-4">
@@ -170,7 +198,7 @@ export const Card = () => {
                             <div className="flex flex-wrap justify-center">
                                 <div className="w-full flex justify-center">
                                     <div className="relative mt-2">
-                                        <img src={ user?.image && `${apiPath}${user.image}` || company?.image && `${apiPath}${company.image}` || defaultImageProfile } className="w-40 h-40 border-4 border-black rounded-full"/>
+                                        <img src={ user?.image || company?.image || defaultImageProfile } className="w-40 h-40 border-4 border-black rounded-full"/>
                                     </div>
                                 </div>
                                 {
@@ -206,6 +234,7 @@ export const Card = () => {
                                     <div className="w-full px-4">
                                         <a href="" className="font-normal text-slate-700 hover:text-slate-400">Acerca de</a>
                                         <p className="font-light leading-relaxed text-slate-600 mb-4">{  user?.about || company?.about }</p>
+                                        <button className="font-normal text-slate-700 hover:text-slate-400" onClick={ onNavigateRecommendedProfile }>Ver perfil</button>
                                     </div>
                                 </div>
                             </div>

--- a/src/pages/matches/Matches.tsx
+++ b/src/pages/matches/Matches.tsx
@@ -1,27 +1,13 @@
-import { useAppDispatch, useAppSelector } from '../../app/hooks'
+import { useAppSelector } from '../../app/hooks'
 import { UserMatch } from './UserMatch'
 import { CompanyMatch } from './CompanyMatch';
-import { useEffect } from 'react';
-import { onRetrieveCompanyMatchesList, onRetrieveUserMatchesList } from '../../app/match/thunks';
+
 
 
 export const Matches = () => {
 
     const { user_data } = useAppSelector(state => state.auth);
     const { userMatches, companyMatches } = useAppSelector(state => state.match);
-    const dispatch = useAppDispatch()
-
-    useEffect(() => {
-        if (user_data){
-            if (user_data.user){
-                dispatch(onRetrieveUserMatchesList());
-            }
-            else {
-                dispatch(onRetrieveCompanyMatchesList());
-            }
-        }
-
-    }, [user_data]);
 
     return (
         <>

--- a/src/pages/matches/RecommendedProfile.tsx
+++ b/src/pages/matches/RecommendedProfile.tsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { useAppSelector } from "../../app/hooks";
+import { CompanyProfile } from "../home/profile/company/CompanyProfile";
+import { UserProfile } from "../home/profile/user/UserProfile";
+import { ICurrentUser } from '../../app/types/interfaces';
+
+
+export const RecommendedProfile = () => {
+    const { currentUser, currentCompany } =  useAppSelector(state => state.match);
+    const [storageRecommendedUser, setStorageRecommendedUser] = useState<ICurrentUser|null>(null);
+    const [storageRecommendedCompany, setStorageRecommendedCompany] = useState<ICurrentUser|null>(null);
+    
+    useEffect(() => {
+        // Persist recommended user/company in localStorage
+        if (localStorage.getItem('recommendedUser')){
+            setStorageRecommendedUser(JSON.parse(localStorage.getItem('recommendedUser')!));
+        }
+        else if (localStorage.getItem('recommendedCompany')){
+            setStorageRecommendedCompany(JSON.parse(localStorage.getItem('recommendedCompany')!));
+        }
+
+    }, [currentUser, currentCompany]);
+
+    return (
+        <>
+            {
+                storageRecommendedCompany?.company
+                        ? <CompanyProfile user={storageRecommendedCompany!} />
+                        : storageRecommendedUser?.user && <UserProfile user={storageRecommendedUser!} />
+            }
+        </>
+    )
+}

--- a/src/pages/messages/Chat.tsx
+++ b/src/pages/messages/Chat.tsx
@@ -10,15 +10,15 @@ export default function Chat() {
             <section className="flex flex-col flex-auto border-l ">
                 {/* Header con quién es el chat */}
                 <HeaderPersonChat />
-                {/* FIN header con quién es el chat */}
+                {/* fin header con quién es el chat */}
 
                 <div className="chat-body p-4 flex-1 overflow-y-scroll" id="messages">
                     <ChatMessagesBody />                          
                 </div>
 
-                {/* FOOTER CHAT */}
+                {/* Footer chat */}
                 <NewMessage />
-                {/* END FOOTER CHAT */}
+                {/* End footer chat */}
             </section>
         </>
   )

--- a/src/pages/skill/SkillModalAdd.tsx
+++ b/src/pages/skill/SkillModalAdd.tsx
@@ -28,7 +28,9 @@ export const SkillModalAdd = () => {
 
             })).unwrap();
             dispatch(setModalClosedSkill());
-            dispatch(onGetUserSkills());
+            dispatch(onGetUserSkills({
+                user_id: user_data!.user!.id
+            }));
         } catch (error) {
             
         }


### PR DESCRIPTION
- Created two queues (arrays): one for user recommendations (companies) & one of companies recommendations (users)

- Implemented recommended user/company profile view

- Hide edit/add/etc options in profile/recommended profile view if i'm not the authenticated user/company

- Conditionally show connect/new message button in recommended-profile 
  1) show connect if i didn't match with the user/company
  2) show new message if if i matched with the user/company

- View roles/experiences/skills sending the id via query_params to the API instead of using access_token (to the recommended profile can get that info without access_token)

NOTE: when log in with a company, recommendations (users) won't work because we're missing the AI Algorithm for that.

